### PR TITLE
解决linux系统编译找不到<direct.h>头文件问题

### DIFF
--- a/resources/code/cpp/leetcode-io.h
+++ b/resources/code/cpp/leetcode-io.h
@@ -8,7 +8,11 @@
 #include <list>
 #include <sstream>
 #include <functional>
+#ifdef _WIN32
 #include <direct.h>
+#else
+#include <unistd.h>
+#endif
 
 #include "leetcode-convert.h"
 #include "leetcode-types.h"


### PR DESCRIPTION
Linux系统下使用<unistd.h>替代<direct.h>
```
#ifdef _WIN32
#include <direct.h>
#else
#include <unistd.h>
#endif
```